### PR TITLE
CircleCi Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,17 +14,28 @@ jobs:
              curl -Ls http://download.blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2 | tar -xjv
              sudo mv blender-${BLENDER_VERSION}-linux-glibc${GLIBC_VERSION}-x86_64 /usr/local/bin/blender
        - run:
-           name: Install Python3.6 and pip
+           name: Install Python3.6
            command: |
              sudo apt-get update
              sudo apt-get install software-properties-common
              sudo add-apt-repository -y ppa:jonathonf/python-3.6
              sudo apt-get update
              sudo apt-get install python3.6 python3.6-dev
-             wget https://bootstrap.pypa.io/get-pip.py
-             sudo python3.6 get-pip.py
+       - run:
+           name: Prepare venv with requirements
+           command: |
+             python3.6 -m venv .venv
+             . .venv/bin/activate
+             pip install -r requirements.txt
+       - run:
+           name: Check versions
+           command: |
+             echo $PATH
+             python --version
+             pip --version
+             docker --version
+             blender --version
        - run:
            name: Run tests
            command: |
-             sudo pip3.6 install -r requirements.txt
-             sudo python3.6 -m pytest
+             python -m pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,15 @@ jobs:
             GLIBC_VERSION: 219
            command: |
              curl -Ls http://download.blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2 | tar -xjv
-             sudo mv blender-${BLENDER_VERSION}-linux-glibc${GLIBC_VERSION}-x86_64 /usr/local/bin/blender
+             sudo ln -s blender-${BLENDER_VERSION}-linux-glibc${GLIBC_VERSION}-x86_64/blender /usr/local/bin/blender
        - run:
            name: Install Python3.6
            command: |
              sudo apt-get update
              sudo apt-get install software-properties-common
-             sudo add-apt-repository -y ppa:jonathonf/python-3.6
+             sudo add-apt-repository -y ppa:deadsnakes/ppa
              sudo apt-get update
-             sudo apt-get install python3.6 python3.6-dev
+             sudo apt-get install python3.6 python3.6-dev python3.6-venv
        - run:
            name: Prepare venv with requirements
            command: |
@@ -30,12 +30,14 @@ jobs:
        - run:
            name: Check versions
            command: |
+             . .venv/bin/activate
              echo $PATH
-             python --version
-             pip --version
-             docker --version
-             blender --version
+             python --version || echo "no python"
+             pip --version || echo "no pip"
+             docker --version || echo "no docker"
+             blender --version || echo "no blender"
        - run:
            name: Run tests
            command: |
+             . .venv/bin/activate
              python -m pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,13 +11,13 @@ jobs:
             BLENDER_VERSION: 2.79
             GLIBC_VERSION: 219
            command: |
-             curl -Ls http://download.blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2 | tar -xjv
-             sudo ln -s blender-${BLENDER_VERSION}-linux-glibc${GLIBC_VERSION}-x86_64/blender /usr/local/bin/blender
+             curl -Ls http://download.blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2 | sudo tar -xjv -C /opt/
+             sudo ln -s /opt/blender-${BLENDER_VERSION}-linux-glibc${GLIBC_VERSION}-x86_64/blender /usr/local/bin/blender
        - run:
            name: Install Python3.6
            command: |
              sudo apt-get update
-             sudo apt-get install software-properties-common
+             sudo apt-get install software-properties-common libglu1
              sudo add-apt-repository -y ppa:deadsnakes/ppa
              sudo apt-get update
              sudo apt-get install python3.6 python3.6-dev python3.6-venv


### PR DESCRIPTION
- No longer use `sudo` for python and pip, use `-m venv` instead
- Print versions of used dependencies
- Re enable blender tests. `tests/test_commands.py sssss ` on [master](https://circleci.com/gh/golemfactory/blenderapp/45)
- Install blender in `/opt`, pytest triggered test in this folder ([this build](https://circleci.com/gh/golemfactory/blenderapp/53))
- install blender dependency `libglu1`