### PR TITLE
Use mirror site for downloading Blender

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
             BLENDER_VERSION: 2.79
             GLIBC_VERSION: 219
            command: |
-             curl -Ls http://download.blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2 | sudo tar -xjv -C /opt/
+             curl -Ls http://mirror.cs.umn.edu/blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2 | sudo tar -xjv -C /opt/
              sudo ln -s /opt/blender-${BLENDER_VERSION}-linux-glibc${GLIBC_VERSION}-x86_64/blender /usr/local/bin/blender
        - run:
            name: Install Python3.6

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -5,8 +5,8 @@ FROM base as blender
 ENV BLENDER_MAJOR 2.79
 ENV BLENDER_VERSION 2.79
 ENV GLIBC_VERSION 219
-ENV BLENDER_BZ2_URL http://download.blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2
-# ENV BLENDER_BZ2_URL http://mirror.cs.umn.edu/blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc211-x86_64.tar.bz2
+# ENV BLENDER_BZ2_URL http://download.blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2
+ENV BLENDER_BZ2_URL http://mirror.cs.umn.edu/blender.org/release/Blender$BLENDER_MAJOR/blender-$BLENDER_VERSION-linux-glibc$GLIBC_VERSION-x86_64.tar.bz2
 
 RUN curl -Ls ${BLENDER_BZ2_URL} | tar -xjv -C / \
   && mv /blender-${BLENDER_VERSION}-linux-glibc${GLIBC_VERSION}-x86_64 /blender \


### PR DESCRIPTION
The download speed decreases dramatically by 75% for unknown reasons and it makes builds time out, the mirror is faster.