### PR TITLE
Update to Task API v0.18.3

### DIFF
--- a/image/golem_blender_app/golem_blender_app/commands/__init__.py
+++ b/image/golem_blender_app/golem_blender_app/commands/__init__.py
@@ -1,0 +1,7 @@
+from .benchmark import benchmark
+from .compute import compute
+from .create_task import create_task
+from .discard_subtasks import discard_subtasks
+from .get_subtask import get_next_subtask
+from .has_pending_subtasks import has_pending_subtasks
+from .verify import verify

--- a/image/golem_blender_app/golem_blender_app/commands/create_task.py
+++ b/image/golem_blender_app/golem_blender_app/commands/create_task.py
@@ -3,13 +3,18 @@ import zipfile
 
 from pathlib import Path
 
+from golem_blender_app import constants
 from golem_blender_app.commands import utils
-from golem_task_api import constants
+from golem_task_api import constants as task_api_constants, envs, structs
 
 
-def create_task(work_dir: Path, max_subtasks_count: int, params: dict) -> None:
-    task_inputs_dir = work_dir / constants.TASK_INPUTS_DIR
-    subtask_inputs_dir = work_dir / constants.SUBTASK_INPUTS_DIR
+def create_task(
+        work_dir: Path,
+        max_subtasks_count: int,
+        params: dict
+) -> structs.Task:
+    task_inputs_dir = work_dir / task_api_constants.TASK_INPUTS_DIR
+    subtask_inputs_dir = work_dir / task_api_constants.SUBTASK_INPUTS_DIR
 
     frame_count = len(utils.string_to_frames(params['frames']))
     if max_subtasks_count <= frame_count:
@@ -27,3 +32,8 @@ def create_task(work_dir: Path, max_subtasks_count: int, params: dict) -> None:
 
     with utils.get_db_connection(work_dir) as db:
         utils.init_tables(db, subtasks_count)
+
+    return envs.create_docker_cpu_task(
+        image=constants.DOCKER_IMAGE,
+        tag=constants.VERSION
+    )

--- a/image/golem_blender_app/golem_blender_app/constants.py
+++ b/image/golem_blender_app/golem_blender_app/constants.py
@@ -1,0 +1,2 @@
+DOCKER_IMAGE = 'golemfactory/blenderapp'
+VERSION = '0.2.0'

--- a/image/golem_blender_app/golem_blender_app/entrypoint.py
+++ b/image/golem_blender_app/golem_blender_app/entrypoint.py
@@ -11,52 +11,49 @@ from golem_task_api import (
     structs,
 )
 
-from golem_blender_app.commands.benchmark import benchmark
-from golem_blender_app.commands.compute import compute
-from golem_blender_app.commands.create_task import create_task
-from golem_blender_app.commands.discard_subtasks import discard_subtasks
-from golem_blender_app.commands.get_subtask import get_next_subtask
-from golem_blender_app.commands.has_pending_subtasks import has_pending_subtasks
-from golem_blender_app.commands.verify import verify
+from golem_blender_app import commands
 
 
 class RequestorHandler(RequestorAppHandler):
+
     async def create_task(
             self,
             task_work_dir: Path,
             max_subtasks_count: int,
             task_params: dict,
-    ) -> None:
-        create_task(task_work_dir, max_subtasks_count, task_params)
+    ) -> structs.Task:
+        return commands.create_task(
+            task_work_dir, max_subtasks_count, task_params)
 
     async def next_subtask(
             self,
             task_work_dir: Path,
+            opaque_node_id: str
     ) -> structs.Subtask:
-        return get_next_subtask(task_work_dir)
+        return commands.get_next_subtask(task_work_dir)
 
     async def verify(
             self,
             task_work_dir: Path,
             subtask_id: str,
     ) -> Tuple[bool, Optional[str]]:
-        return await verify(task_work_dir, subtask_id)
+        return await commands.verify(task_work_dir, subtask_id)
 
     async def discard_subtasks(
             self,
             task_work_dir: Path,
             subtask_ids: List[str],
     ) -> List[str]:
-        return discard_subtasks(task_work_dir, subtask_ids)
+        return commands.discard_subtasks(task_work_dir, subtask_ids)
 
     async def has_pending_subtasks(
             self,
             task_work_dir: Path,
     ) -> bool:
-        return has_pending_subtasks(task_work_dir)
+        return commands.has_pending_subtasks(task_work_dir)
 
     async def run_benchmark(self, work_dir: Path) -> float:
-        return await benchmark(work_dir)
+        return await commands.benchmark(work_dir)
 
 
 class ProviderHandler(ProviderAppHandler):
@@ -66,10 +63,10 @@ class ProviderHandler(ProviderAppHandler):
             subtask_id: str,
             subtask_params: dict,
     ) -> Path:
-        return await compute(task_work_dir, subtask_id, subtask_params)
+        return await commands.compute(task_work_dir, subtask_id, subtask_params)
 
     async def run_benchmark(self, work_dir: Path) -> float:
-        return await benchmark(work_dir)
+        return await commands.benchmark(work_dir)
 
 
 async def main(

--- a/image/golem_blender_app/requirements.txt
+++ b/image/golem_blender_app/requirements.txt
@@ -10,4 +10,4 @@ PyWavelets==1.0.2
 opencv-python==4.0.0.21
 
 typing
-golem_task_api==0.15.1
+golem_task_api==0.18.3

--- a/image/golem_blender_app/setup.py
+++ b/image/golem_blender_app/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup
 
+from golem_blender_app import constants
+
+
 def parse_requirements():
     """
     Parse requirements.txt file
@@ -26,7 +29,7 @@ install_requires, dependencies = parse_requirements()
 
 setup(
     name='Golem-Blender-App',
-    version='0.1.0',
+    version=constants.VERSION,
     url='https://github.com/golemfactory/blenderapp',
     maintainer='The Golem team',
     maintainer_email='tech@golem.network',

--- a/tests/simulationbase.py
+++ b/tests/simulationbase.py
@@ -150,8 +150,10 @@ class SimulationBase(abc.ABC):
                 self._get_task_api_service,
                 task_id,
             )
-            subtask_ids = \
-                await task_lifecycle_util.compute_remaining_subtasks(task_id)
+            subtask_ids = await task_lifecycle_util.compute_remaining_subtasks(
+                task_id=task_id,
+                opaque_node_id='whatever'
+            )
             self._check_results(
                 task_lifecycle_util.req_task_outputs_dir,
                 task_params["format"],
@@ -163,8 +165,10 @@ class SimulationBase(abc.ABC):
                 await requestor_client.discard_subtasks(task_id, subtask_ids)
             assert discarded_subtask_ids == subtask_ids
             assert await requestor_client.has_pending_subtasks(task_id)
-            subtask_ids = \
-                await task_lifecycle_util.compute_remaining_subtasks(task_id)
+            subtask_ids = await task_lifecycle_util.compute_remaining_subtasks(
+                task_id=task_id,
+                opaque_node_id='whatever'
+            )
             self._check_results(
                 task_lifecycle_util.req_task_outputs_dir,
                 task_params["format"],
@@ -178,8 +182,10 @@ class SimulationBase(abc.ABC):
             )
             assert discarded_subtask_ids == subtask_ids[:1]
             assert await requestor_client.has_pending_subtasks(task_id)
-            subtask_ids = \
-                await task_lifecycle_util.compute_remaining_subtasks(task_id)
+            subtask_ids = await task_lifecycle_util.compute_remaining_subtasks(
+                task_id=task_id,
+                opaque_node_id='whatever'
+            )
             assert len(subtask_ids) == 1
             self._check_results(
                 task_lifecycle_util.req_task_outputs_dir,


### PR DESCRIPTION
* Return Docker image name and version from `create_task` command (assuming that Docker image will be tagged with the package version)
* Accept `opaque_node_id` parameter for `next_subtask`.
* Pass `opaque_node_id` parameter for `compute_remaining_subtasks` in tests.