### PR TITLE
Fix race condition in shutdown test

### DIFF
--- a/image/golem_blender_app/requirements.txt
+++ b/image/golem_blender_app/requirements.txt
@@ -10,4 +10,4 @@ PyWavelets==1.0.2
 opencv-python==4.0.0.21
 
 typing
-golem_task_api==0.19.0
+golem_task_api==0.19.1


### PR DESCRIPTION
Waiting for the first completed future from `[shutdown_defer, benchmark_defer]` doesn't have to return `shutdown_future`. It's completely fine for the other one to finish first with the exception. It's a race condition here.

As seen in this build: https://circleci.com/gh/golemfactory/blenderapp/242?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link