### PR TITLE
Permissive result_dir creation (parents=True, exist_ok=True)

### DIFF
--- a/image/golem_blender_app/golem_blender_app/commands/compute.py
+++ b/image/golem_blender_app/golem_blender_app/commands/compute.py
@@ -16,7 +16,7 @@ async def compute(
     subtask_work_dir = work_dir.subtask_dir(subtask_id)
     resources_dir = work_dir / 'extracted_subtask_inputs'
     result_dir = subtask_work_dir / 'result'
-    result_dir.mkdir()
+    result_dir.mkdir(parents=True, exist_ok=True)
     for rid in params['resources']:
         with zipfile.ZipFile(work_dir.subtask_inputs_dir / rid, 'r') as zipf:
             zipf.extractall(resources_dir)

--- a/image/golem_blender_app/golem_blender_app/constants.py
+++ b/image/golem_blender_app/golem_blender_app/constants.py
@@ -1,2 +1,2 @@
 DOCKER_IMAGE = 'golemfactory/blenderapp'
-VERSION = '0.3.1'
+VERSION = '0.3.2'


### PR DESCRIPTION
The parent path of `result_dir` (`subtask_work_dir`) does not initially exist and the `Compute` method fails