### PR TITLE
Update to Task API v0.23.0 (AbortSubtask call)

### DIFF
--- a/image/golem_blender_app/golem_blender_app/commands/__init__.py
+++ b/image/golem_blender_app/golem_blender_app/commands/__init__.py
@@ -1,3 +1,4 @@
+from .abort_subtask import abort_subtask
 from .abort_task import abort_task
 from .benchmark import benchmark
 from .compute import compute

--- a/image/golem_blender_app/golem_blender_app/commands/abort_subtask.py
+++ b/image/golem_blender_app/golem_blender_app/commands/abort_subtask.py
@@ -1,0 +1,10 @@
+from golem_blender_app.commands import utils
+from golem_task_api import dirutils
+
+
+def abort_subtask(
+        work_dir: dirutils.RequestorTaskDir,
+        subtask_id: str
+) -> None:
+    with utils.get_db_connection(work_dir) as db:
+        utils.update_subtask_status(db, subtask_id, utils.SubtaskStatus.ABORTED)

--- a/image/golem_blender_app/golem_blender_app/commands/verify.py
+++ b/image/golem_blender_app/golem_blender_app/commands/verify.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Tuple, Optional
 import json
-import os
 import shutil
 import zipfile
 

--- a/image/golem_blender_app/golem_blender_app/constants.py
+++ b/image/golem_blender_app/golem_blender_app/constants.py
@@ -1,2 +1,2 @@
 DOCKER_IMAGE = 'golemfactory/blenderapp'
-VERSION = '0.5.0'
+VERSION = '0.6.0'

--- a/image/golem_blender_app/golem_blender_app/render_tools/blender_render.py
+++ b/image/golem_blender_app/golem_blender_app/render_tools/blender_render.py
@@ -3,6 +3,7 @@ import os
 import stat
 import sys
 from multiprocessing import cpu_count
+from subprocess import SubprocessError
 from typing import List
 
 from . import scenefileeditor
@@ -180,7 +181,8 @@ async def render(parameters: dict,
         print(cmd, file=sys.stderr)
         exit_code = await exec_cmd(cmd)
         if exit_code is not 0:
-            sys.exit(exit_code)
+            raise SubprocessError(
+                f'Render process exited with code {exit_code}')
 
         crop_counter += 1
 

--- a/image/golem_blender_app/requirements.txt
+++ b/image/golem_blender_app/requirements.txt
@@ -10,4 +10,4 @@ PyWavelets==1.0.2
 opencv-python==4.0.0.21
 
 typing
-golem_task_api==0.22.0
+golem_task_api==0.23.0


### PR DESCRIPTION
Bonus: Fixed sys.exit() in render function that would blow up the whole GRPC server in case of an error.