### PR TITLE
Use new command from task-api to build the app definition.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
            command: |
              python3.6 -m venv .venv
              . .venv/bin/activate
+             pip install -r requirements-build.txt
              pip install -r requirements.txt -r requirements-lint.txt
              pip install -r image/golem_blender_app/requirements.txt
        - run:

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -42,10 +42,10 @@ COPY golem_blender_app/requirements.txt /tmp
 RUN pip install -r /tmp/requirements.txt
 
 # Use following lines to work with the unreleased task-api module
-# RUN apt-get install -y git
-# RUN pip uninstall -y golem-task-api
-# ENV GITCOMMIT=bfc2872c44d89132e43667d826b53e666c6453dc
-# RUN pip install git+https://github.com/golemfactory/task-api@$GITCOMMIT#subdirectory=python
+RUN apt-get install -y git
+RUN pip uninstall -y golem-task-api
+ENV GITCOMMIT=mwu/task-api-build-tool
+RUN pip install git+https://github.com/golemfactory/task-api@$GITCOMMIT#subdirectory=python
 
 # Check to see that all libraries are available
 # We don't need libgfortran

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -42,10 +42,10 @@ COPY golem_blender_app/requirements.txt /tmp
 RUN pip install -r /tmp/requirements.txt
 
 # Use following lines to work with the unreleased task-api module
-RUN apt-get install -y git
-RUN pip uninstall -y golem-task-api
-ENV GITCOMMIT=mwu/task-api-build-tool
-RUN pip install git+https://github.com/golemfactory/task-api@$GITCOMMIT#subdirectory=python
+# RUN apt-get install -y git
+# RUN pip uninstall -y golem-task-api
+# ENV GITCOMMIT=bfc2872c44d89132e43667d826b53e666c6453dc
+# RUN pip install git+https://github.com/golemfactory/task-api@$GITCOMMIT#subdirectory=python
 
 # Check to see that all libraries are available
 # We don't need libgfortran

--- a/image/golem_blender_app/golem_blender_app/entrypoint.py
+++ b/image/golem_blender_app/golem_blender_app/entrypoint.py
@@ -8,7 +8,7 @@ from golem_task_api import (
     RequestorAppHandler,
     constants as api_constants,
     dirutils,
-    entrypoint,
+    main as api_main,
     enums,
     structs,
 )
@@ -105,7 +105,7 @@ async def main(
         requestor_handler: Optional[RequestorHandler] = None,
         provider_handler: Optional[ProviderHandler] = None,
 ):
-    await entrypoint(
+    await api_main(
         work_dir,
         argv,
         requestor_handler=requestor_handler,

--- a/image/golem_blender_app/requirements.txt
+++ b/image/golem_blender_app/requirements.txt
@@ -1,7 +1,6 @@
 --extra-index-url https://builds.golem.network
 dataclasses==0.6
-#golem_task_api==0.24.1
-git+https://github.com/golemfactory/task-api@mwu/task-api-build-tool#egg=golem_task_api&subdirectory=python
+golem_task_api==0.24.4
 numpy==1.15.4
 opencv-python==4.0.0.21
 OpenEXR==1.3.2

--- a/image/golem_blender_app/requirements.txt
+++ b/image/golem_blender_app/requirements.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://builds.golem.network
 dataclasses==0.6
-golem_task_api==0.24.4
+golem_task_api==0.24.5
 numpy==1.15.4
 opencv-python==4.0.0.21
 OpenEXR==1.3.2

--- a/image/golem_blender_app/requirements.txt
+++ b/image/golem_blender_app/requirements.txt
@@ -1,6 +1,7 @@
 --extra-index-url https://builds.golem.network
 dataclasses==0.6
-golem_task_api==0.24.1
+#golem_task_api==0.24.1
+git+https://github.com/golemfactory/task-api@mwu/task-api-build-tool#egg=golem_task_api&subdirectory=python
 numpy==1.15.4
 opencv-python==4.0.0.21
 OpenEXR==1.3.2

--- a/image/golem_blender_app/setup.py
+++ b/image/golem_blender_app/setup.py
@@ -1,6 +1,17 @@
 from setuptools import setup
 
 from golem_blender_app import constants
+from golem_task_api.apputils.app_definition import BuildAppDefCommand
+
+
+class BlenderBuildAppDefCommand(BuildAppDefCommand):
+    def run(self):
+        self.config['name'] = constants.DOCKER_IMAGE
+        self.config['requestor_prereq'] = {
+            "image": constants.DOCKER_IMAGE,
+            "tag": constants.VERSION
+        }
+        super().run()
 
 
 def parse_requirements():
@@ -25,13 +36,16 @@ def parse_requirements():
             requirements.append(line)
     return requirements, dependency_links
 
+
 install_requires, dependencies = parse_requirements()
 
 setup(
     name='Golem-Blender-App',
     version=constants.VERSION,
+    description='Rendering with Blender, the free and open source 3D creation suite',
+    license='GPLv3',
     url='https://github.com/golemfactory/blenderapp',
-    maintainer='The Golem team',
+    maintainer='Golem Factory GmbH',
     maintainer_email='tech@golem.network',
     packages=[
         'golem_blender_app',
@@ -51,4 +65,7 @@ setup(
     python_requires='>=3.6',
     install_requires=install_requires,
     dependency_links=dependencies,
+    cmdclass={
+        'build_app_def': BlenderBuildAppDefCommand,
+    }
 )

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,9 +1,4 @@
 # I dunno why --extra-index-url is needed since, since it's present in the golem_blender_app
 # but it doesn't work without it
 --extra-index-url https://builds.golem.network
--e image/golem_blender_app
-
-docker==3.7.0
-pytest==3.6.3
-pytest-asyncio==0.10.0
-async-generator==1.10
+git+https://github.com/golemfactory/task-api@mwu/task-api-build-tool#egg=golem_task_api&subdirectory=python

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,5 @@
+# git+https://github.com/golemfactory/task-api@master#egg=golem_task_api&subdirectory=python
 # I dunno why --extra-index-url is needed since, since it's present in the golem_blender_app
 # but it doesn't work without it
 --extra-index-url https://builds.golem.network
-git+https://github.com/golemfactory/task-api@mwu/task-api-build-tool#egg=golem_task_api&subdirectory=python
+golem_task_api==0.24.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # I dunno why --extra-index-url is needed since, since it's present in the golem_blender_app
 # but it doesn't work without it
 --extra-index-url https://builds.golem.network
-# git+https://github.com/golemfactory/task-api@bfc2872c44d89132e43667d826b53e666c6453dc#subdirectory=python
+git+https://github.com/golemfactory/task-api@mwu/task-api-build-tool#subdirectory=python#egg=golem_task_api
 -e image/golem_blender_app
 
 docker==3.7.0

--- a/task-api-config.json
+++ b/task-api-config.json
@@ -1,0 +1,5 @@
+{
+   "requestor_env":"docker_cpu",
+   "max_benchmark_score":10000.0,
+   "market_strategy":"brass"
+}


### PR DESCRIPTION
added `python setup.py build_app_def` command to produce the app definition file for distribution in golem.

Depends on merge and release of https://github.com/golemfactory/task-api/pull/64